### PR TITLE
Remove widget.is_hidden=True for Django 1.7 #22137

### DIFF
--- a/datetimezone_field/widgets.py
+++ b/datetimezone_field/widgets.py
@@ -71,7 +71,6 @@ class SplitHiddenTimeTimeZoneWidget(SplitTimeTimeZoneWidget):
         super(SplitHiddenTimeTimeZoneWidget, self).__init__(attrs, time_format)
         for widget in self.widgets:
             widget.input_type = 'hidden'
-            widget.is_hidden = True
 
 
 class AdminSplitTimeTimeZone(SplitTimeTimeZoneWidget):
@@ -121,7 +120,6 @@ class SplitHiddenDateTimeTimeZoneWidget(SplitDateTimeTimeZoneWidget):
         super(SplitHiddenDateTimeTimeZoneWidget, self).__init__(attrs, date_format, time_format)
         for widget in self.widgets:
             widget.input_type = 'hidden'
-            widget.is_hidden = True
 
 
 class AdminSplitDateTimeTimeZone(SplitDateTimeTimeZoneWidget):


### PR DESCRIPTION
widget.is_hidden was made read-only in Django 1.7 in:
https://github.com/django/django/pull/2372/files

It is now a property that returns `True` if the `widget.input_type == 'hidden'`, so the hidden inputs here should continue to work as expected by just removing these lines.

Discussion in Django ticket #22137 https://code.djangoproject.com/ticket/22137

In a subsequent commit https://github.com/django/django/commit/306283bf358470b7d439822af90051ac62e95bae for the Django 1.8 release, the setter and deprecation warning were removed entirely, so trying to set this property raises an exception, which causes `django-datetimezone-field` to break some views.  (I first encountered this interacting with a view in https://github.com/jsocol/django-waffle)
