### PR TITLE
Committing a fix here as what I believe to be a better workaround for…

### DIFF
--- a/datetimezone_field/fields.py
+++ b/datetimezone_field/fields.py
@@ -103,13 +103,3 @@ class SplitDateTimeTimeZoneField(MultiValueField):
 
         return None
 
-    def _has_changed(self, initial, data):
-        # TimeZoneFormField._has_changed returns True always here, so we rely solely
-        # on the other fields.
-        if initial is None:
-            initial = ['' for x in range(0, len(data))]
-        else:
-            if not isinstance(initial, list):
-                initial = self.widget.decompress(initial)
-        return (self.fields[0]._has_changed(initial[0], data[0]) or
-                self.fields[1]._has_changed(initial[1], data[1]))

--- a/datetimezone_field/widgets.py
+++ b/datetimezone_field/widgets.py
@@ -109,6 +109,22 @@ class SplitDateTimeTimeZoneWidget(MultiWidget):
             return [value.date(), value.time().replace(microsecond=0), tzinfo]
         return [None, None, tzinfo]
 
+    def value_from_datadict(self, data, files, name):
+        """
+        account for the fact that the timezone widget always returns a value (the default)
+        even without interaction, and with a blank date and time, it doesn't make sense
+        """
+        value_list = MultiWidget.value_from_datadict(self, data, files, name)
+
+        DATE_INDEX = 0
+        TIME_INDEX = 1
+        TZ_INDEX = 2
+
+        if not value_list[DATE_INDEX] and not value_list[TIME_INDEX]:
+            value_list[TZ_INDEX] = u''
+
+        return value_list
+
 
 class SplitHiddenDateTimeTimeZoneWidget(SplitDateTimeTimeZoneWidget):
     """


### PR DESCRIPTION
… https://github.com/GradConnection/django-datetimezone-field/commit/62bf52eff11ac838ec18d548bf2c54c2b1a6191f

Particularly, that fix doesn't account for the use case of keeping the exact same time and date while changing the datetime. Instead of ignoring the time zone when comparing if the field changed, I changed the widget to check if both the date and time fields are empty, and if so, set the timezone to empty as well, as a timezone by itself (with neither a date nor a time) makes no sense.

If this is sensible, perhaps SplitTimeTimeZoneWidget needs a similar implementation, checking only the time field? What do you think?
